### PR TITLE
Fix mmap error checking

### DIFF
--- a/plparse/xmlparser.c
+++ b/plparse/xmlparser.c
@@ -924,7 +924,7 @@ int main (int argc, char **argv)
       continue;
     }
     buf = mmap (NULL, st.st_size, PROT_READ, MAP_SHARED, fd, 0);
-    if (!buf)
+    if (buf == MAP_FAILED)
     {
       perror (argv[i]);
       if (close (fd))


### PR DESCRIPTION
mmap returns MAP_FAILED, not NULL, on failure.
